### PR TITLE
bitcoin-core: Migrate to CMake

### DIFF
--- a/projects/bitcoin-core/Dockerfile
+++ b/projects/bitcoin-core/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y \
   automake autotools-dev bsdmainutils build-essential cmake curl g++-multilib libtool make \
   patch pkg-config python3 wget zip
 
-RUN git clone --depth=1 https://github.com/bitcoin/bitcoin.git bitcoin-core
+RUN git clone --depth=1 --branch 240716-cmake https://github.com/hebasto/bitcoin.git bitcoin-core
 RUN git clone --depth=1 https://github.com/bitcoin-core/qa-assets bitcoin-core/assets && \
   rm -rf bitcoin-core/assets/.git  # Remove git history to save storage
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz

--- a/projects/bitcoin-core/build.sh
+++ b/projects/bitcoin-core/build.sh
@@ -59,21 +59,29 @@ export CPPFLAGS="-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -DBOOST_M
 
 # Build the fuzz targets
 
-sed -i "s|PROVIDE_FUZZ_MAIN_FUNCTION|NEVER_PROVIDE_MAIN_FOR_OSS_FUZZ|g" "./configure.ac"
-./autogen.sh
+sed -i "s|PROVIDE_FUZZ_MAIN_FUNCTION|NEVER_PROVIDE_MAIN_FOR_OSS_FUZZ|g" "./src/test/fuzz/util/CMakeLists.txt"
 
 # OSS-Fuzz will provide CC, CXX, etc. So only set:
-# * --enable-fuzz, see https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md
-# * CONFIG_SITE, see https://github.com/bitcoin/bitcoin/blob/master/depends/README.md
+# * -DBUILD_FOR_FUZZING=ON, see https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md
+# * --toolchain, see https://github.com/bitcoin/bitcoin/blob/master/depends/README.md
+EXTRA_BUILD_OPTIONS=
 if [ "$SANITIZER" = "memory" ]; then
   # _FORTIFY_SOURCE is not compatible with MSAN.
-  export CPPFLAGS="${CPPFLAGS} -U_FORTIFY_SOURCE"
+  EXTRA_BUILD_OPTIONS="-DAPPEND_CPPFLAGS='-U_FORTIFY_SOURCE'"
 fi
 
-CONFIG_SITE="$PWD/depends/$BUILD_TRIPLET/share/config.site" ./configure --enable-fuzz SANITIZER_LDFLAGS="$LIB_FUZZING_ENGINE"
-make -j$(nproc)
+cmake -B build_fuzz \
+  --toolchain depends/${BUILD_TRIPLET}/toolchain.cmake \
+  `# Setting these flags to an empty string ensures that the flags set by an OSS-Fuzz environment remain unaltered` \
+  -DCMAKE_C_FLAGS_RELWITHDEBINFO="" \
+  -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="" \
+  -DBUILD_FOR_FUZZING=ON \
+  -DSANITIZER_LDFLAGS="$LIB_FUZZING_ENGINE" \
+  $EXTRA_BUILD_OPTIONS
 
-WRITE_ALL_FUZZ_TARGETS_AND_ABORT="/tmp/a" "./src/test/fuzz/fuzz" || true
+cmake --build build_fuzz -j$(nproc)
+
+WRITE_ALL_FUZZ_TARGETS_AND_ABORT="/tmp/a" "./build_fuzz/src/test/fuzz/fuzz" || true
 readarray FUZZ_TARGETS < "/tmp/a"
 if [ -n "${OSS_FUZZ_CI-}" ]; then
   # When running in CI, check the first targets only to save time and disk space
@@ -85,16 +93,16 @@ fi
 # executable with a "magic string" as the name of the fuzz target.
 #
 # An alternative to mocking the string in the finished binary would be to
-# replace the string in the source code and re-invoke 'make'. This is slower,
+# replace the string in the source code and re-invoke 'cmake --build'. This is slower,
 # so use the hack.
 export MAGIC_STR="b5813eee2abc9d3358151f298b75a72264ffa119d2f71ae7fefa15c4b70b4bc5b38e87e3107a730f25891ea428b2b4fabe7a84f5bfa73c79e0479e085e4ff157"
 sed -i "s|std::getenv(\"FUZZ\")|\"$MAGIC_STR\"|g" "./src/test/fuzz/fuzz.cpp"
-make -j$(nproc)
+cmake --build build_fuzz -j$(nproc)
 
 # Replace the magic string with the actual name of each fuzz target
 for fuzz_target in ${FUZZ_TARGETS[@]}; do
   df --human-readable ./src
-  python3 -c "c_str_target=b\"${fuzz_target}\x00\";c_str_magic=b\"$MAGIC_STR\";dat=open('./src/test/fuzz/fuzz','rb').read();dat=dat.replace(c_str_magic, c_str_target+c_str_magic[len(c_str_target):]);open(\"$OUT/$fuzz_target\",'wb').write(dat)"
+  python3 -c "c_str_target=b\"${fuzz_target}\x00\";c_str_magic=b\"$MAGIC_STR\";dat=open('./build_fuzz/src/test/fuzz/fuzz','rb').read();dat=dat.replace(c_str_magic, c_str_target+c_str_magic[len(c_str_target):]);open(\"$OUT/$fuzz_target\",'wb').write(dat)"
 
   chmod +x "$OUT/$fuzz_target"
   (


### PR DESCRIPTION
This PR provides an OSS-Fuzz branch based on the rolling [`cmake-staging`](https://github.com/hebasto/bitcoin/tree/cmake-staging) branch.

It is supposed to be updated periodically to keep synced.